### PR TITLE
Add slate-react to the bundled source guide

### DIFF
--- a/docs/walkthroughs/using-the-bundled-source.md
+++ b/docs/walkthroughs/using-the-bundled-source.md
@@ -47,6 +47,7 @@ To make things easier, for quick prototyping, you can also use the [`unpkg.com`]
 <script src="https://unpkg.com/react-dom/umd/react-dom-server.browser.production.min.js"></script>
 <script src="https://unpkg.com/immutable/dist/immutable.js"></script>
 <script src="https://unpkg.com/slate/dist/slate.js"></script>
+<script src="https://unpkg.com/slate-react/dist/slate-react.js"></script>
 ```
 
 That's it, you're ready to go!


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Improving documentation.

<!-- 
If you have a question, ask it in our Slack channel instead:

https://slate-slack.herokuapp.com/
-->

#### What's the new behavior?

Example in documentation was lacking react-slate which in reality is needed in order to successfully use Slate with React.

<!-- 
Please include at least one of the following: 

- A GIF showing the new behavior in action.
- A code sample showing the new API in action.
- A description of how the new behavior works.

If you don't include one of these, there's a very good chance your pull request will take longer to review. Thank you!
-->

#### How does this change work?

<!-- 
If your change is non-trivial, please include a short description of how the new logic works, and why you decided to solve it the way you did. This is incredibly helpful so that reviewers don't have to guess based on the code.
-->

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [ ] The new code matches the existing patterns and styles.
* [ ] The tests pass with `yarn test`.
* [ ] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [ ] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
